### PR TITLE
fix(labels): enable underscore support and add custom label rendering

### DIFF
--- a/charts/cloudrun/common/common.schema.json
+++ b/charts/cloudrun/common/common.schema.json
@@ -454,18 +454,18 @@
                 }
             ],
             "patternProperties": {
-                "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$": {
+                "^[a-z0-9]([-_a-z0-9]*[a-z0-9])?$": {
                     "$id": "label",
                     "type": "string",
                     "maxLength": 63,
-                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                    "pattern": "^[a-z0-9]([-_a-z0-9]*[a-z0-9])?$",
                     "description": "Label key and value must conform to the Cloud Run label schema of lowercase alphanumeric characters, hyphens, and underscores and be 63 characters or less.",
                     "$since": "0.1.0"
                 }
             },
             "propertyNames": {
                 "maxLength": 63,
-                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                "pattern": "^[a-z0-9]([-_a-z0-9]*[a-z0-9])?$"
             },
             "additionalProperties": false,
             "$since": "0.1.0"

--- a/charts/cloudrun/common/templates/_helpers.tpl
+++ b/charts/cloudrun/common/templates/_helpers.tpl
@@ -42,6 +42,11 @@ release: {{ .Release.Name | quote }}
 helmless-chart: {{ .Chart.Name | quote }}
 helmless-chart-version: {{ .Chart.Version | replace "." "_" | quote }}
 managed-by: helmless
+{{- with .Values.labels }}
+{{- range $key, $value := . }}
+{{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/cloudrun/job/values-edit-me.schema.json
+++ b/charts/cloudrun/job/values-edit-me.schema.json
@@ -80,6 +80,10 @@
       "$ref": "../common/common.schema.json#/$defs/serviceAccountName",
       "$since": "0.1.1"
     },
+    "labels": {
+      "$ref": "../common/common.schema.json#/$defs/labels",
+      "$since": "0.1.1"
+    },
     "description": {
       "$ref": "../common/common.schema.json#/$defs/description",
       "$since": "0.1.1"

--- a/charts/cloudrun/job/values.schema.json
+++ b/charts/cloudrun/job/values.schema.json
@@ -201,6 +201,31 @@
       ],
       "$since": "0.1.0"
     },
+    "labels": {
+      "description": "Labels to add to the Cloud Run container. Must conform to the Cloud Run label schema of lowercase alphanumeric characters, hyphens, and underscores and be 63 characters or less.",
+      "type": "object",
+      "examples": [
+        {
+          "my-label": "my-value"
+        }
+      ],
+      "patternProperties": {
+        "^[a-z0-9]([-_a-z0-9]*[a-z0-9])?$": {
+          "$id": "label",
+          "type": "string",
+          "maxLength": 63,
+          "pattern": "^[a-z0-9]([-_a-z0-9]*[a-z0-9])?$",
+          "description": "Label key and value must conform to the Cloud Run label schema of lowercase alphanumeric characters, hyphens, and underscores and be 63 characters or less.",
+          "$since": "0.1.0"
+        }
+      },
+      "propertyNames": {
+        "maxLength": 63,
+        "pattern": "^[a-z0-9]([-_a-z0-9]*[a-z0-9])?$"
+      },
+      "additionalProperties": false,
+      "$since": "0.1.0"
+    },
     "description": {
       "description": "A human-readable description of the CloudRun service.",
       "type": "string",

--- a/charts/cloudrun/service/Chart.lock
+++ b/charts/cloudrun/service/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: google-cloudrun-common
   repository: file://../common
-  version: 0.1.1
-digest: sha256:fb1700b3b55554891c2bb43b08a5e2534ef64697f80668265d53b39717ee7e28
-generated: "2025-03-29T18:41:41.501265+01:00"
+  version: 0.3.0
+digest: sha256:1d8cc0338099f009bc2074541f6a8b3a20752c2cc5af8a8b3966f9578c1cf3ec
+generated: "2026-03-11T14:14:42.007969+01:00"

--- a/charts/cloudrun/service/values-edit-me.schema.json
+++ b/charts/cloudrun/service/values-edit-me.schema.json
@@ -83,6 +83,10 @@
       "$ref": "../common/common.schema.json#/$defs/serviceAccountName",
       "$since": "0.1.1"
     },
+    "labels": {
+      "$ref": "../common/common.schema.json#/$defs/labels",
+      "$since": "0.1.1"
+    },
     "description": {
       "$ref": "../common/common.schema.json#/$defs/description",
       "$since": "0.1.1"

--- a/charts/cloudrun/service/values.schema.json
+++ b/charts/cloudrun/service/values.schema.json
@@ -204,6 +204,31 @@
       ],
       "$since": "0.1.0"
     },
+    "labels": {
+      "description": "Labels to add to the Cloud Run container. Must conform to the Cloud Run label schema of lowercase alphanumeric characters, hyphens, and underscores and be 63 characters or less.",
+      "type": "object",
+      "examples": [
+        {
+          "my-label": "my-value"
+        }
+      ],
+      "patternProperties": {
+        "^[a-z0-9]([-_a-z0-9]*[a-z0-9])?$": {
+          "$id": "label",
+          "type": "string",
+          "maxLength": 63,
+          "pattern": "^[a-z0-9]([-_a-z0-9]*[a-z0-9])?$",
+          "description": "Label key and value must conform to the Cloud Run label schema of lowercase alphanumeric characters, hyphens, and underscores and be 63 characters or less.",
+          "$since": "0.1.0"
+        }
+      },
+      "propertyNames": {
+        "maxLength": 63,
+        "pattern": "^[a-z0-9]([-_a-z0-9]*[a-z0-9])?$"
+      },
+      "additionalProperties": false,
+      "$since": "0.1.0"
+    },
     "description": {
       "description": "A human-readable description of the CloudRun service.",
       "type": "string",


### PR DESCRIPTION
# Description

Fixes #15

Custom labels in Cloud Run service and job charts were broken due to three issues:

- Schema validation error — The `values-edit-me.schema.json` files didn't reference the labels property, causing Helm to reject any labels input despite `common.schema.json` defining it.
- Underscore not supported — The label regex patterns excluded underscores, so keys like cr_short_name would fail validation even after fixing the schema.
- Silent rendering failure — The `helmless.cloudrun.labels` helper never iterated over `.Values.labels`, so custom labels would be silently omitted from the rendered manifest.

## What this PR provides

- Fix regex patterns in common.schema.json to allow underscores in label keys/values
- Add labels property reference to service and job values-edit-me.schema.json
- Update helmless.cloudrun.labels helper to render .Values.labels in manifests